### PR TITLE
Enable iCloud Keychain synchronization for API credentials

### DIFF
--- a/Sources/ASC/KeychainHelper.swift
+++ b/Sources/ASC/KeychainHelper.swift
@@ -17,7 +17,8 @@ enum KeychainHelper {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecValueData as String: data
+            kSecValueData as String: data,
+            kSecAttrSynchronizable as String: true
         ]
 
         // Lösche das bestehende Element, falls es existiert
@@ -32,7 +33,8 @@ enum KeychainHelper {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
         ]
 
         var result: AnyObject?
@@ -51,7 +53,8 @@ enum KeychainHelper {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: account
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
         ]
 
         let status = SecItemDelete(query as CFDictionary)


### PR DESCRIPTION
## Summary
- Added `kSecAttrSynchronizable` attribute to enable iCloud Keychain sync
- App Store Connect credentials are now automatically synchronized across all Macs with the same iCloud account
- Maintains backward compatibility when reading/deleting existing non-synced items

## Changes
1. **addKeychainItem**: Set `kSecAttrSynchronizable=true` to enable sync for newly stored items
2. **getKeychainItem**: Use `kSecAttrSynchronizable=kSecAttrSynchronizableAny` to find both synced and non-synced items
3. **deleteKeychainItem**: Use `kSecAttrSynchronizable=kSecAttrSynchronizableAny` to delete any matching item

## Test plan
- [ ] Build project successfully (`swift build`)
- [ ] Run `asc init` on one Mac to store credentials
- [ ] Verify credentials sync to other Macs with same iCloud account
- [ ] Verify existing credentials can still be read/deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)