### PR TITLE
Xcode Cloud: 'runs' commands for build runs & artifacts + global --json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,30 @@ Commands use a resource-based noun-verb pattern, grouped by resource:
 asc init / clear                          # Credential management
 asc apps list                             # App listing
 asc versions create / show / select-build / submit  # Version lifecycle
-asc workflows list / trigger / status     # Xcode Cloud workflows
+asc workflows list / trigger / status     # Xcode Cloud workflow definitions
+asc runs list / view / download           # Xcode Cloud build runs & artifacts
 ```
 
-- **ASC.swift**: Main entry point registering command groups
-- **Commands/**: Flat directory with prefixed filenames (e.g., `VersionCreateCommand.swift`, `WorkflowsTriggerCommand.swift`). Command groups (e.g., `VersionsCommand.swift`) register their subcommands.
-- **KeychainHelper.swift**: Centralized keychain operations with static service identifier `"de.JulianKahnert.asc"`
+Mirrors the `gh` CLI split: `workflows` manages the workflow *definitions* (like
+`gh workflow`), `runs` works with their individual *executions* and artifacts
+(like `gh run`). Resources are flat top-level nouns; ownership is expressed via
+the `<app>` argument and filters (e.g. `--workflow`), not command nesting.
+
+- **ASCMain** (`ASC.swift`): the root command that registers the command groups. It lives in the importable **`ASC` library target**; the actual `@main` executable is a thin wrapper in `Sources/ASCExecutable/Entry.swift` that calls `ASCMain.main()`. This split lets the test target import the library and exercise commands directly.
+- **Commands/**: Flat directory with prefixed filenames (e.g., `VersionCreateCommand.swift`, `RunsDownloadCommand.swift`). Command groups (e.g., `VersionsCommand.swift`, `RunsCommand.swift`) register their subcommands.
+- **KeychainHelper.swift**: Centralized keychain operations with static service identifier `"de.JulianKahnert.asc"`; also hosts shared `resolveAppID()` and `getCiProductID()` helpers.
+- **VersionLogic.swift / RunsLogic.swift**: Fetch/parse logic extracted from the command types so it can be unit-tested in isolation against mock API responses.
+- **JSONOutput.swift**: Shared `--json` output helper (see below).
+- **Platform+Extensions.swift**: `Platform` display-name helper for CLI output.
+
+### JSON Output (`--json`)
+
+Every data-returning command accepts a global `--json` flag. When set, the
+command prints a single JSON document (via `JSONOutput.emit`) and suppresses the
+human-readable output, so other clients can parse results programmatically.
+Currently wired into `apps list`, `versions show`, `workflows list`,
+`workflows status`, and all `runs` subcommands. Command logic builds a `Codable`
+model and either emits it as JSON or renders it as text.
 
 ### Key Dependencies
 
@@ -74,6 +92,29 @@ The `workflows` group uses App Store Connect CI endpoints:
 - **list**: Gets CI product for app, then lists workflows with name/enabled/ID
 - **trigger**: Resolves workflow by name, finds branch git reference, posts `CiBuildRunCreateRequest`
 - **status**: Lists recent build runs per workflow with progress/completion status
+
+### Runs Commands (build runs & artifacts)
+
+The `runs` group inspects Xcode Cloud build runs and their downloadable
+artifacts. Logic lives in `RunsLogic.swift`. The relevant API hierarchy is:
+
+```
+CiProduct → CiWorkflow → CiBuildRun → CiBuildAction → { CiArtifact, CiIssue, CiTestResult }
+```
+
+Key detail: **artifacts hang off `CiBuildAction`, not `CiBuildRun`** — there is
+no `/ciBuildRuns/{id}/artifacts`. To get all artifacts of a build, iterate the
+run's actions and collect each action's artifacts.
+
+- **list**: Lists recent build runs for the app (`ciProducts/{id}/buildRuns`), or a single workflow's runs (`ciWorkflows/{id}/buildRuns`) with `--workflow`. Resolves branch and workflow names from the `included` payload.
+- **view**: Resolves a build *number* to its run, fetches its actions with issue counts, and (for failed / all actions) their issues and downloadable artifacts. `--failed` restricts to failed actions.
+- **download**: Fetches fresh pre-signed artifact URLs and downloads matching files to `--output` (default cwd). `--type` filters by file type (LOG_BUNDLE, RESULT_BUNDLE, ARCHIVE, …); `--action` filters by action name.
+
+**Artifact download URLs**: `CiArtifact.downloadUrl` is a short-lived,
+pre-signed URL that needs no App Store Connect credentials to fetch, but expires
+(typically within minutes). Always re-fetch it from the API immediately before
+downloading — never treat it as a durable link. `runs download` does this and
+uses a plain `URLSession` to save the file.
 
 ## Platform Requirements
 

--- a/Sources/ASC/ASC.swift
+++ b/Sources/ASC/ASC.swift
@@ -13,7 +13,8 @@ public struct ASCMain: AsyncParsableCommand {
             ClearCommand.self,
             AppsCommand.self,
             VersionsCommand.self,
-            WorkflowsCommand.self
+            WorkflowsCommand.self,
+            RunsCommand.self
         ]
     )
 }

--- a/Sources/ASC/Commands/AppsListCommand.swift
+++ b/Sources/ASC/Commands/AppsListCommand.swift
@@ -13,12 +13,28 @@ struct AppsListCommand: AsyncParsableCommand {
             """
     )
 
+    @Flag(name: .long, help: "Output the result as JSON.")
+    var json = false
+
+    /// A single app for `--json` output.
+    struct AppSummary: Codable {
+        let id: String
+        let name: String
+        let bundleID: String
+    }
+
     func run() async throws {
         let provider = try KeychainHelper.createAPIProvider()
 
-        print("📱 Fetching apps from App Store Connect...\n")
+        if !json { print("📱 Fetching apps from App Store Connect...\n") }
 
-        let apps = try await Self.listApps(provider: provider)
+        let tuples = try await Self.listApps(provider: provider)
+        let apps = tuples.map { AppSummary(id: $0.id, name: $0.name, bundleID: $0.bundleID) }
+
+        if json {
+            try JSONOutput.emit(apps)
+            return
+        }
 
         if apps.isEmpty {
             print("No apps found in your account.")

--- a/Sources/ASC/Commands/RunsCommand.swift
+++ b/Sources/ASC/Commands/RunsCommand.swift
@@ -1,0 +1,17 @@
+import ArgumentParser
+
+/// Command group for Xcode Cloud build runs (the executions of a workflow).
+///
+/// Mirrors `gh run`: `workflows` manages the workflow *definitions*, `runs`
+/// works with their individual *executions* and their artifacts.
+struct RunsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "runs",
+        abstract: "Inspect Xcode Cloud build runs and their artifacts.",
+        subcommands: [
+            RunsListCommand.self,
+            RunsViewCommand.self,
+            RunsDownloadCommand.self
+        ]
+    )
+}

--- a/Sources/ASC/Commands/RunsDownloadCommand.swift
+++ b/Sources/ASC/Commands/RunsDownloadCommand.swift
@@ -1,0 +1,132 @@
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+/// Downloads the artifacts of a build run (`gh run download`).
+struct RunsDownloadCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "download",
+        abstract: "Download a build run's artifacts (logs, result bundles, archives …).",
+        discussion: """
+            Fetches fresh pre-signed URLs from the API and downloads the matching
+            artifacts to a local directory, so other clients can debug the build.
+            Without --type, all artifacts are downloaded.
+
+            Artifact types: LOG_BUNDLE, RESULT_BUNDLE, ARCHIVE, ARCHIVE_EXPORT,
+            TEST_PRODUCTS, XCODEBUILD_PRODUCTS, STAPLED_NOTARIZED_ARCHIVE.
+
+            Examples:
+              $ asc runs download com.example.app 42 --type LOG_BUNDLE
+              $ asc runs download com.example.app 42 --output ./ci-logs
+              $ asc runs download com.example.app 42 --json
+            """
+    )
+
+    @Argument(help: "The App ID or Bundle ID from App Store Connect.")
+    var appID: String
+
+    @Argument(help: "The build run number (as shown by 'asc runs list').")
+    var number: Int
+
+    @Option(help: "Disambiguate the build number to a specific workflow.")
+    var workflow: String?
+
+    @Option(help: "Only download artifacts of this type (e.g. LOG_BUNDLE).")
+    var type: String?
+
+    @Option(help: "Only download artifacts of this action (e.g. Build, Test).")
+    var action: String?
+
+    @Option(help: "Directory to download artifacts into.")
+    var output: String = "."
+
+    @Flag(name: .long, help: "Output the result as JSON.")
+    var json = false
+
+    /// Describes one downloaded artifact for `--json` output.
+    struct DownloadedArtifact: Codable {
+        let fileName: String
+        let fileType: String?
+        let fileSize: Int?
+        let path: String
+    }
+
+    func run() async throws {
+        let typeFilter = try type.map { try CiArtifact.Attributes.FileType.parse($0) }
+
+        let provider = try KeychainHelper.createAPIProvider()
+        let resolvedAppID = try await KeychainHelper.resolveAppID(provider: provider, appIDOrBundleID: appID)
+        let productID = try await KeychainHelper.getCiProductID(provider: provider, appID: resolvedAppID)
+
+        var workflowID: String?
+        if let workflow {
+            workflowID = try await RunsLogic.resolveWorkflowID(provider: provider, productID: productID, name: workflow)
+        }
+
+        let run = try await RunsLogic.resolveRun(
+            provider: provider,
+            productID: productID,
+            workflowID: workflowID,
+            number: number
+        )
+
+        let actions = try await RunsLogic.fetchActions(
+            provider: provider,
+            runID: run.id,
+            query: .init(actionFilter: action, includeArtifacts: true)
+        )
+
+        let artifacts = actions.flatMap { $0.artifacts }.filter { artifact in
+            guard let typeFilter else { return true }
+            return artifact.fileType == typeFilter.rawValue
+        }
+
+        if artifacts.isEmpty {
+            if json {
+                try JSONOutput.emit([DownloadedArtifact]())
+            } else {
+                print("No matching artifacts found for build #\(number).")
+            }
+            return
+        }
+
+        let directory = URL(fileURLWithPath: output, isDirectory: true)
+        let downloaded = try await downloadAll(artifacts, to: directory, quiet: json)
+
+        if json {
+            try JSONOutput.emit(downloaded)
+        } else {
+            for item in downloaded {
+                print("✅ \(item.path)")
+            }
+        }
+    }
+
+    /// Downloads each artifact into `directory`, returning the saved files.
+    private func downloadAll(
+        _ artifacts: [ArtifactInfo],
+        to directory: URL,
+        quiet: Bool
+    ) async throws -> [DownloadedArtifact] {
+        var downloaded: [DownloadedArtifact] = []
+        for artifact in artifacts {
+            guard let urlString = artifact.downloadUrl else { continue }
+            let fileName = artifact.fileName ?? "\(artifact.fileType ?? "artifact")-\(artifact.id)"
+
+            if !quiet { print("Downloading \(fileName)…") }
+
+            let path = try await RunsLogic.downloadArtifact(
+                from: urlString,
+                fileName: fileName,
+                to: directory
+            )
+            downloaded.append(DownloadedArtifact(
+                fileName: fileName,
+                fileType: artifact.fileType,
+                fileSize: artifact.fileSize,
+                path: path.path
+            ))
+        }
+        return downloaded
+    }
+}

--- a/Sources/ASC/Commands/RunsListCommand.swift
+++ b/Sources/ASC/Commands/RunsListCommand.swift
@@ -1,0 +1,71 @@
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+/// Lists recent Xcode Cloud build runs for an app (`gh run list`).
+struct RunsListCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List recent Xcode Cloud build runs for an app.",
+        discussion: """
+            Examples:
+              $ asc runs list com.example.app
+              $ asc runs list com.example.app --workflow "Release Build" --limit 20
+              $ asc runs list com.example.app --json
+            """
+    )
+
+    @Argument(help: "The App ID or Bundle ID from App Store Connect.")
+    var appID: String
+
+    @Option(help: "Only show runs of this workflow.")
+    var workflow: String?
+
+    @Option(help: "Maximum number of runs to show.")
+    var limit: Int = 10
+
+    @Flag(name: .long, help: "Output the result as JSON.")
+    var json = false
+
+    func run() async throws {
+        let provider = try KeychainHelper.createAPIProvider()
+        let resolvedAppID = try await KeychainHelper.resolveAppID(provider: provider, appIDOrBundleID: appID)
+        let productID = try await KeychainHelper.getCiProductID(provider: provider, appID: resolvedAppID)
+
+        var workflowID: String?
+        if let workflow {
+            workflowID = try await RunsLogic.resolveWorkflowID(provider: provider, productID: productID, name: workflow)
+        }
+
+        let runs = try await RunsLogic.listRuns(
+            provider: provider,
+            productID: productID,
+            workflowID: workflowID,
+            limit: limit
+        )
+
+        if json {
+            try JSONOutput.emit(runs)
+            return
+        }
+
+        Self.printRuns(runs, showWorkflow: workflow == nil)
+    }
+
+    static func printRuns(_ runs: [RunSummary], showWorkflow: Bool) {
+        guard !runs.isEmpty else {
+            print("No build runs found.")
+            return
+        }
+
+        for run in runs {
+            let number = run.number.map { "#\($0)" } ?? "#?"
+            let status = run.completionStatus ?? run.executionProgress ?? "UNKNOWN"
+            let branch = run.branch ?? "unknown"
+            let sha = run.commitSha ?? ""
+            let time = WorkflowsStatusCommand.formatRelativeTime(run.createdDate)
+            let workflowName = showWorkflow ? "  \(run.workflowName ?? "")" : ""
+            print("  \(number)  \(status)\(workflowName)  \(branch)  \(sha)  \(time)")
+        }
+    }
+}

--- a/Sources/ASC/Commands/RunsViewCommand.swift
+++ b/Sources/ASC/Commands/RunsViewCommand.swift
@@ -1,0 +1,131 @@
+import ArgumentParser
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+/// Shows a single build run with its actions, issues and artifacts (`gh run view`).
+struct RunsViewCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "view",
+        abstract: "Show a build run's actions, issues and artifacts.",
+        discussion: """
+            Prints each action (Build/Test/Analyze/Archive) with its status and
+            issue counts. Failing actions list their errors inline, and each
+            action's downloadable artifacts are shown (use 'asc runs download').
+
+            Examples:
+              $ asc runs view com.example.app 42
+              $ asc runs view com.example.app 42 --failed
+              $ asc runs view com.example.app 42 --json
+            """
+    )
+
+    @Argument(help: "The App ID or Bundle ID from App Store Connect.")
+    var appID: String
+
+    @Argument(help: "The build run number (as shown by 'asc runs list').")
+    var number: Int
+
+    @Option(help: "Disambiguate the build number to a specific workflow.")
+    var workflow: String?
+
+    @Flag(help: "Only show actions that failed.")
+    var failed = false
+
+    @Flag(name: .long, help: "Output the result as JSON.")
+    var json = false
+
+    func run() async throws {
+        let provider = try KeychainHelper.createAPIProvider()
+        let resolvedAppID = try await KeychainHelper.resolveAppID(provider: provider, appIDOrBundleID: appID)
+        let productID = try await KeychainHelper.getCiProductID(provider: provider, appID: resolvedAppID)
+
+        var workflowID: String?
+        if let workflow {
+            workflowID = try await RunsLogic.resolveWorkflowID(provider: provider, productID: productID, name: workflow)
+        }
+
+        let run = try await RunsLogic.resolveRun(
+            provider: provider,
+            productID: productID,
+            workflowID: workflowID,
+            number: number
+        )
+
+        let actions = try await RunsLogic.fetchActions(
+            provider: provider,
+            runID: run.id,
+            query: .init(onlyFailed: failed, includeIssues: true, includeArtifacts: true)
+        )
+
+        let detail = RunDetail(run: run, actions: actions)
+
+        if json {
+            try JSONOutput.emit(detail)
+            return
+        }
+
+        Self.printDetail(detail)
+    }
+
+    static func printDetail(_ detail: RunDetail) {
+        let run = detail.run
+        let number = run.number.map { "#\($0)" } ?? "#?"
+        let status = run.completionStatus ?? run.executionProgress ?? "UNKNOWN"
+        let branch = run.branch ?? "unknown"
+        let sha = run.commitSha ?? ""
+        print("Run \(number)  \(status)  \(run.workflowName ?? "")  \(branch)@\(sha)\n")
+
+        if detail.actions.isEmpty {
+            print("  No actions found.")
+            return
+        }
+
+        for action in detail.actions {
+            let actionStatus = action.completionStatus ?? action.executionProgress ?? "UNKNOWN"
+            let counts = Self.formatCounts(action.issueCounts)
+            print("  \(action.name ?? action.actionType ?? "Action")  \(actionStatus)\(counts)")
+
+            for issue in action.issues {
+                let location = issue.file.map { file in
+                    issue.line.map { "\(file):\($0)" } ?? file
+                } ?? ""
+                let type = issue.type ?? "ISSUE"
+                let message = issue.message ?? ""
+                print("       \(type)  \(location)  \(message)")
+            }
+
+            for artifact in action.artifacts {
+                let type = artifact.fileType ?? "ARTIFACT"
+                let name = artifact.fileName ?? artifact.id
+                let size = Self.formatSize(artifact.fileSize)
+                print("       ↓ \(type)  \(name)  \(size)")
+            }
+            print("")
+        }
+    }
+
+    static func formatCounts(_ counts: IssueCountsInfo?) -> String {
+        guard let counts else { return "" }
+        var parts: [String] = []
+        if let errors = counts.errors, errors > 0 { parts.append("\(errors) error\(errors == 1 ? "" : "s")") }
+        if let failures = counts.testFailures, failures > 0 {
+            parts.append("\(failures) test failure\(failures == 1 ? "" : "s")")
+        }
+        if let warnings = counts.warnings, warnings > 0 {
+            parts.append("\(warnings) warning\(warnings == 1 ? "" : "s")")
+        }
+        return parts.isEmpty ? "" : "  (\(parts.joined(separator: ", ")))"
+    }
+
+    static func formatSize(_ bytes: Int?) -> String {
+        guard let bytes else { return "" }
+        let units = ["B", "KB", "MB", "GB"]
+        var value = Double(bytes)
+        var unit = 0
+        while value >= 1024 && unit < units.count - 1 {
+            value /= 1024
+            unit += 1
+        }
+        return unit == 0 ? "\(bytes) B" : String(format: "%.1f %@", value, units[unit])
+    }
+}

--- a/Sources/ASC/Commands/VersionShowCommand.swift
+++ b/Sources/ASC/Commands/VersionShowCommand.swift
@@ -17,19 +17,67 @@ struct VersionShowCommand: AsyncParsableCommand {
     @Argument(help: "The App ID or Bundle ID from App Store Connect.")
     var appID: String
 
+    @Flag(name: .long, help: "Output the result as JSON.")
+    var json = false
+
+    /// A prepared version for `--json` output.
+    struct VersionInfo: Codable {
+        let platform: String
+        let version: String
+        let state: String
+        let build: String?
+    }
+
     func run() async throws {
         let provider = try KeychainHelper.createAPIProvider()
         let resolvedAppID = try await KeychainHelper.resolveAppID(provider: provider, appIDOrBundleID: appID)
 
-        try await Self.execute(provider: provider, appID: resolvedAppID)
+        try await Self.execute(provider: provider, appID: resolvedAppID, json: json)
     }
 
-    static func execute(provider: APIProvider, appID: String) async throws {
+    static func execute(provider: APIProvider, appID: String, json: Bool = false) async throws {
+        if json {
+            var infos = try await versionInfos(provider: provider, appID: appID, platform: .ios)
+            infos += try await versionInfos(provider: provider, appID: appID, platform: .macOs)
+            try JSONOutput.emit(infos)
+            return
+        }
+
         print("\n📱 iOS Versions:")
         try await showVersionInfo(provider: provider, appID: appID, platform: .ios)
 
         print("\n💻 macOS Versions:")
         try await showVersionInfo(provider: provider, appID: appID, platform: .macOs)
+    }
+
+    /// Fetches prepared versions for a platform as structured data.
+    static func versionInfos(
+        provider: APIProvider,
+        appID: String,
+        platform: Platform
+    ) async throws -> [VersionInfo] {
+        var parameters = APIEndpoint.V1.Apps.WithID.AppStoreVersions.GetParameters()
+        parameters.fieldsAppStoreVersions = [.versionString, .platform, .appStoreState]
+        parameters.limit = 10
+
+        let request = APIEndpoint.v1.apps.id(appID).appStoreVersions.get(parameters: parameters)
+        let response = try await provider.request(request)
+
+        let filtered = response.data.filter { $0.attributes?.platform == platform }
+        let buildMap = try await getBuildsMap(provider: provider, appID: appID, platform: platform)
+
+        return filtered.compactMap { version -> VersionInfo? in
+            guard let versionString = version.attributes?.versionString,
+                  let state = version.attributes?.appStoreState?.rawValue else {
+                return nil
+            }
+            return VersionInfo(
+                platform: platform.name,
+                version: versionString,
+                state: state,
+                build: buildMap[version.id]
+            )
+        }
     }
 
     static func showVersionInfo(

--- a/Sources/ASC/Commands/WorkflowsListCommand.swift
+++ b/Sources/ASC/Commands/WorkflowsListCommand.swift
@@ -17,20 +17,37 @@ struct WorkflowsListCommand: AsyncParsableCommand {
     @Argument(help: "The App ID or Bundle ID from App Store Connect.")
     var appID: String
 
+    @Flag(name: .long, help: "Output the result as JSON.")
+    var json = false
+
+    /// A single workflow for `--json` output.
+    struct WorkflowSummary: Codable {
+        let id: String
+        let name: String
+        let enabled: Bool
+    }
+
     func run() async throws {
         let provider = try KeychainHelper.createAPIProvider()
         let resolvedAppID = try await KeychainHelper.resolveAppID(provider: provider, appIDOrBundleID: appID)
         let productID = try await KeychainHelper.getCiProductID(provider: provider, appID: resolvedAppID)
 
-        try await Self.execute(provider: provider, productID: productID, appIDDisplay: appID)
+        try await Self.execute(provider: provider, productID: productID, appIDDisplay: appID, json: json)
     }
 
     static func execute(
         provider: APIProvider,
         productID: String,
-        appIDDisplay: String
+        appIDDisplay: String,
+        json: Bool = false
     ) async throws {
         let workflows = try await listWorkflows(provider: provider, productID: productID)
+
+        if json {
+            let summaries = workflows.map { WorkflowSummary(id: $0.id, name: $0.name, enabled: $0.isEnabled) }
+            try JSONOutput.emit(summaries)
+            return
+        }
 
         if workflows.isEmpty {
             print("No workflows found.")

--- a/Sources/ASC/Commands/WorkflowsStatusCommand.swift
+++ b/Sources/ASC/Commands/WorkflowsStatusCommand.swift
@@ -20,18 +20,38 @@ struct WorkflowsStatusCommand: AsyncParsableCommand {
     @Option(help: "Filter by workflow name.")
     var workflow: String?
 
+    @Flag(name: .long, help: "Output the result as JSON.")
+    var json = false
+
+    /// A single build run for `--json` output.
+    struct StatusRun: Codable {
+        let number: Int?
+        let branch: String?
+        let commitSha: String?
+        let status: String
+        let startReason: String?
+        let createdDate: Date?
+    }
+
+    /// A workflow together with its recent build runs, for `--json` output.
+    struct WorkflowStatus: Codable {
+        let workflow: String
+        let runs: [StatusRun]
+    }
+
     func run() async throws {
         let provider = try KeychainHelper.createAPIProvider()
         let resolvedAppID = try await KeychainHelper.resolveAppID(provider: provider, appIDOrBundleID: appID)
         let productID = try await KeychainHelper.getCiProductID(provider: provider, appID: resolvedAppID)
 
-        try await Self.execute(provider: provider, productID: productID, workflowFilter: workflow)
+        try await Self.execute(provider: provider, productID: productID, workflowFilter: workflow, json: json)
     }
 
     static func execute(
         provider: APIProvider,
         productID: String,
-        workflowFilter: String?
+        workflowFilter: String?,
+        json: Bool = false
     ) async throws {
         let workflows = try await listWorkflows(provider: provider, productID: productID)
 
@@ -48,38 +68,57 @@ struct WorkflowsStatusCommand: AsyncParsableCommand {
             targetWorkflows = workflows
         }
 
-        var foundAny = false
-
+        var statuses: [WorkflowStatus] = []
         for targetWorkflow in targetWorkflows {
             let buildRuns = try await getRecentBuildRuns(
                 provider: provider,
                 workflowID: targetWorkflow.id
             )
-
             guard !buildRuns.isEmpty else { continue }
-            foundAny = true
 
-            if workflowFilter != nil {
-                print("Recent builds for \"\(targetWorkflow.name)\":\n")
-            } else {
-                print("\(targetWorkflow.name):")
+            let runs = buildRuns.map { run in
+                StatusRun(
+                    number: run.number,
+                    branch: run.sourceBranchName,
+                    commitSha: run.sourceCommitSha,
+                    status: formatStatus(progress: run.executionProgress, completion: run.completionStatus),
+                    startReason: run.startReason,
+                    createdDate: run.createdDate
+                )
             }
-
-            for run in buildRuns {
-                let number = run.number.map { "#\($0)" } ?? "?"
-                let status = formatStatus(progress: run.executionProgress, completion: run.completionStatus)
-                let branch = run.sourceBranchName ?? "unknown"
-                let time = formatRelativeTime(run.createdDate)
-
-                let reason = run.startReason.map { "(\($0))" } ?? ""
-                let sha = run.sourceCommitSha ?? ""
-                print("  \(number)  \(branch)  \(sha)  \(status)  \(time)  \(reason)")
-            }
-            print("")
+            statuses.append(WorkflowStatus(workflow: targetWorkflow.name, runs: runs))
         }
 
-        if !foundAny {
+        if json {
+            try JSONOutput.emit(statuses)
+            return
+        }
+
+        printStatuses(statuses, filtered: workflowFilter != nil)
+    }
+
+    static func printStatuses(_ statuses: [WorkflowStatus], filtered: Bool) {
+        guard !statuses.isEmpty else {
             print("No recent builds found.")
+            return
+        }
+
+        for status in statuses {
+            if filtered {
+                print("Recent builds for \"\(status.workflow)\":\n")
+            } else {
+                print("\(status.workflow):")
+            }
+
+            for run in status.runs {
+                let number = run.number.map { "#\($0)" } ?? "?"
+                let branch = run.branch ?? "unknown"
+                let time = formatRelativeTime(run.createdDate)
+                let reason = run.startReason.map { "(\($0))" } ?? ""
+                let sha = run.commitSha ?? ""
+                print("  \(number)  \(branch)  \(sha)  \(run.status)  \(time)  \(reason)")
+            }
+            print("")
         }
     }
 

--- a/Sources/ASC/JSONOutput.swift
+++ b/Sources/ASC/JSONOutput.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Shared helpers for emitting machine-readable JSON from commands.
+///
+/// Every command accepts a global `--json` flag. When set, the command prints
+/// a single JSON document to stdout (and nothing else) so other clients can
+/// parse the result programmatically.
+enum JSONOutput {
+    /// Encodes `value` as a pretty-printed, stable-key-ordered JSON string.
+    static func string<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(value)
+        return String(bytes: data, encoding: .utf8) ?? ""
+    }
+
+    /// Prints `value` as JSON to stdout.
+    static func emit<T: Encodable>(_ value: T) throws {
+        print(try string(value))
+    }
+}

--- a/Sources/ASC/RunsLogic.swift
+++ b/Sources/ASC/RunsLogic.swift
@@ -1,0 +1,357 @@
+import AppStoreConnect_Swift_SDK
+import ArgumentParser
+import Foundation
+
+// MARK: - Output models
+
+/// A single Xcode Cloud build run (`ciBuildRuns`), mirroring `gh run`.
+struct RunSummary: Codable {
+    let id: String
+    let number: Int?
+    let workflowName: String?
+    let branch: String?
+    let commitSha: String?
+    let executionProgress: String?
+    let completionStatus: String?
+    let startReason: String?
+    let createdDate: Date?
+}
+
+/// Issue counts for a build action (`ciIssueCounts`).
+struct IssueCountsInfo: Codable {
+    let errors: Int?
+    let warnings: Int?
+    let analyzerWarnings: Int?
+    let testFailures: Int?
+}
+
+/// A single issue reported by a build action (`ciIssues`).
+struct IssueInfo: Codable {
+    let type: String?
+    let message: String?
+    let file: String?
+    let line: Int?
+    let category: String?
+}
+
+/// A downloadable artifact of a build action (`ciArtifacts`).
+///
+/// - Note: `downloadUrl` is a short-lived, pre-signed URL. It expires (typically
+///   within minutes) and must be re-fetched from the API before use. Prefer
+///   `asc runs download` over passing the URL around.
+struct ArtifactInfo: Codable {
+    let id: String
+    let fileType: String?
+    let fileName: String?
+    let fileSize: Int?
+    let downloadUrl: String?
+}
+
+/// A build action within a run (`ciBuildActions`) — the Build/Test/Analyze/Archive steps.
+struct ActionInfo: Codable {
+    let id: String
+    let name: String?
+    let actionType: String?
+    let executionProgress: String?
+    let completionStatus: String?
+    let issueCounts: IssueCountsInfo?
+    let issues: [IssueInfo]
+    let artifacts: [ArtifactInfo]
+}
+
+/// A build run together with its actions — the payload of `asc runs view`.
+struct RunDetail: Codable {
+    let run: RunSummary
+    let actions: [ActionInfo]
+}
+
+// MARK: - Logic
+
+/// Fetch/parse logic for Xcode Cloud build runs, actions, issues and artifacts.
+///
+/// Kept separate from the command types so it can be exercised in isolation by
+/// the test suite (mirroring `VersionLogic`).
+enum RunsLogic {
+
+    /// Resolves a workflow name to its `ciWorkflows` ID within a product.
+    static func resolveWorkflowID(
+        provider: APIProvider,
+        productID: String,
+        name: String
+    ) async throws -> String {
+        var parameters = APIEndpoint.V1.CiProducts.WithID.Workflows.GetParameters()
+        parameters.fieldsCiWorkflows = [.name]
+
+        let request = APIEndpoint.v1.ciProducts.id(productID).workflows.get(parameters: parameters)
+        let response = try await provider.request(request)
+
+        guard let matched = response.data.first(where: { $0.attributes?.name == name }) else {
+            let available = response.data.compactMap { $0.attributes?.name }
+            throw ValidationError(
+                "Workflow '\(name)' not found. Available workflows: \(available.joined(separator: ", "))"
+            )
+        }
+        return matched.id
+    }
+
+    /// Lists recent build runs for a product, optionally scoped to a single workflow.
+    ///
+    /// Results are sorted newest-first by build number.
+    static func listRuns(
+        provider: APIProvider,
+        productID: String,
+        workflowID: String?,
+        limit: Int
+    ) async throws -> [RunSummary] {
+        let response: CiBuildRunsResponse
+        if let workflowID {
+            var parameters = APIEndpoint.V1.CiWorkflows.WithID.BuildRuns.GetParameters()
+            parameters.fieldsCiBuildRuns = [
+                .number, .executionProgress, .completionStatus,
+                .createdDate, .startReason, .sourceCommit,
+                .sourceBranchOrTag, .workflow
+            ]
+            parameters.sort = [.minusnumber]
+            parameters.limit = limit
+            parameters.include = [.sourceBranchOrTag, .workflow]
+            parameters.fieldsScmGitReferences = [.name]
+            parameters.fieldsCiWorkflows = [.name]
+
+            let request = APIEndpoint.v1.ciWorkflows.id(workflowID).buildRuns.get(parameters: parameters)
+            response = try await provider.request(request)
+        } else {
+            var parameters = APIEndpoint.V1.CiProducts.WithID.BuildRuns.GetParameters()
+            parameters.fieldsCiBuildRuns = [
+                .number, .executionProgress, .completionStatus,
+                .createdDate, .startReason, .sourceCommit,
+                .sourceBranchOrTag, .workflow
+            ]
+            parameters.sort = [.minusnumber]
+            parameters.limit = limit
+            parameters.include = [.sourceBranchOrTag, .workflow]
+            parameters.fieldsScmGitReferences = [.name]
+            parameters.fieldsCiWorkflows = [.name]
+
+            let request = APIEndpoint.v1.ciProducts.id(productID).buildRuns.get(parameters: parameters)
+            response = try await provider.request(request)
+        }
+
+        return summaries(from: response)
+    }
+
+    /// Resolves a human-facing build number to its full run summary.
+    static func resolveRun(
+        provider: APIProvider,
+        productID: String,
+        workflowID: String?,
+        number: Int
+    ) async throws -> RunSummary {
+        // Build numbers are unique per workflow but the API offers no number
+        // filter, so page through the most recent runs and match locally.
+        let runs = try await listRuns(
+            provider: provider,
+            productID: productID,
+            workflowID: workflowID,
+            limit: 100
+        )
+
+        guard let matched = runs.first(where: { $0.number == number }) else {
+            throw ValidationError(
+                "Build #\(number) not found among the 100 most recent runs. "
+                    + "Use 'asc runs list' to see available build numbers."
+            )
+        }
+        return matched
+    }
+
+    /// Selects which actions to fetch and how much detail to include.
+    struct ActionQuery {
+        /// Only include actions whose name matches (case-insensitive).
+        var actionFilter: String?
+        /// Only include actions that failed.
+        var onlyFailed = false
+        /// Also fetch each action's issues.
+        var includeIssues = false
+        /// Also fetch each action's artifacts.
+        var includeArtifacts = false
+    }
+
+    /// Fetches the actions of a run, optionally with their issues and artifacts.
+    static func fetchActions(
+        provider: APIProvider,
+        runID: String,
+        query: ActionQuery
+    ) async throws -> [ActionInfo] {
+        var parameters = APIEndpoint.V1.CiBuildRuns.WithID.Actions.GetParameters()
+        parameters.fieldsCiBuildActions = [
+            .name, .actionType, .executionProgress, .completionStatus, .issueCounts
+        ]
+        parameters.limit = 50
+
+        let request = APIEndpoint.v1.ciBuildRuns.id(runID).actions.get(parameters: parameters)
+        let response = try await provider.request(request)
+
+        var actions = response.data
+        if let actionFilter = query.actionFilter {
+            actions = actions.filter { $0.attributes?.name?.caseInsensitiveCompare(actionFilter) == .orderedSame }
+        }
+        if query.onlyFailed {
+            actions = actions.filter { $0.attributes?.completionStatus == .failed }
+        }
+
+        var result: [ActionInfo] = []
+        for action in actions {
+            let issues = query.includeIssues
+                ? try await fetchIssues(provider: provider, actionID: action.id) : []
+            let artifacts = query.includeArtifacts
+                ? try await fetchArtifacts(provider: provider, actionID: action.id) : []
+
+            let counts = action.attributes?.issueCounts.map {
+                IssueCountsInfo(
+                    errors: $0.errors,
+                    warnings: $0.warnings,
+                    analyzerWarnings: $0.analyzerWarnings,
+                    testFailures: $0.testFailures
+                )
+            }
+
+            result.append(ActionInfo(
+                id: action.id,
+                name: action.attributes?.name,
+                actionType: action.attributes?.actionType?.rawValue,
+                executionProgress: action.attributes?.executionProgress?.rawValue,
+                completionStatus: action.attributes?.completionStatus?.rawValue,
+                issueCounts: counts,
+                issues: issues,
+                artifacts: artifacts
+            ))
+        }
+        return result
+    }
+
+    /// Fetches the issues (errors/warnings/test failures) of a single action.
+    static func fetchIssues(
+        provider: APIProvider,
+        actionID: String
+    ) async throws -> [IssueInfo] {
+        let request = APIEndpoint.v1.ciBuildActions.id(actionID).issues.get(
+            fieldsCiIssues: [.issueType, .message, .fileSource, .category],
+            limit: 200
+        )
+        let response = try await provider.request(request)
+
+        return response.data.map { issue in
+            IssueInfo(
+                type: issue.attributes?.issueType?.rawValue,
+                message: issue.attributes?.message,
+                file: issue.attributes?.fileSource?.path,
+                line: issue.attributes?.fileSource?.lineNumber,
+                category: issue.attributes?.category
+            )
+        }
+    }
+
+    /// Fetches the artifacts (logs, result bundles, archives …) of a single action.
+    static func fetchArtifacts(
+        provider: APIProvider,
+        actionID: String
+    ) async throws -> [ArtifactInfo] {
+        let request = APIEndpoint.v1.ciBuildActions.id(actionID).artifacts.get(
+            fieldsCiArtifacts: [.fileType, .fileName, .fileSize, .downloadURL],
+            limit: 200
+        )
+        let response = try await provider.request(request)
+
+        return response.data.map { artifact in
+            ArtifactInfo(
+                id: artifact.id,
+                fileType: artifact.attributes?.fileType?.rawValue,
+                fileName: artifact.attributes?.fileName,
+                fileSize: artifact.attributes?.fileSize,
+                downloadUrl: artifact.attributes?.downloadURL?.absoluteString
+            )
+        }
+    }
+
+    /// Downloads a pre-signed artifact URL to a local file, returning its path.
+    ///
+    /// The URL requires no App Store Connect credentials but is short-lived, so
+    /// it should be fetched immediately before calling this.
+    static func downloadArtifact(
+        from urlString: String,
+        fileName: String,
+        to directory: URL
+    ) async throws -> URL {
+        guard let url = URL(string: urlString) else {
+            throw ValidationError("Artifact has no valid download URL.")
+        }
+
+        let (tempURL, response) = try await URLSession.shared.download(from: url)
+
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw ValidationError(
+                "Failed to download \(fileName): HTTP \(http.statusCode). "
+                    + "The pre-signed URL may have expired — re-run the command."
+            )
+        }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let destination = directory.appendingPathComponent(fileName)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+        return destination
+    }
+
+    // MARK: - Private
+
+    /// Maps a `CiBuildRunsResponse` to `RunSummary`, resolving branch and
+    /// workflow names from the response's `included` payload.
+    private static func summaries(from response: CiBuildRunsResponse) -> [RunSummary] {
+        var branchNameByID: [String: String] = [:]
+        var workflowNameByID: [String: String] = [:]
+
+        for item in response.included ?? [] {
+            switch item {
+            case .scmGitReference(let ref):
+                if let name = ref.attributes?.name { branchNameByID[ref.id] = name }
+            case .ciWorkflow(let workflow):
+                if let name = workflow.attributes?.name { workflowNameByID[workflow.id] = name }
+            default:
+                break
+            }
+        }
+
+        return response.data.map { run in
+            let branchID = run.relationships?.sourceBranchOrTag?.data?.id
+            let workflowID = run.relationships?.workflow?.data?.id
+            let fullSha = run.attributes?.sourceCommit?.commitSha
+
+            return RunSummary(
+                id: run.id,
+                number: run.attributes?.number,
+                workflowName: workflowID.flatMap { workflowNameByID[$0] },
+                branch: branchID.flatMap { branchNameByID[$0] },
+                commitSha: fullSha.map { String($0.prefix(7)) },
+                executionProgress: run.attributes?.executionProgress?.rawValue,
+                completionStatus: run.attributes?.completionStatus?.rawValue,
+                startReason: run.attributes?.startReason?.rawValue,
+                createdDate: run.attributes?.createdDate
+            )
+        }
+    }
+}
+
+// MARK: - Artifact file-type parsing
+
+extension CiArtifact.Attributes.FileType {
+    /// Parses a user-supplied `--type` value (case-insensitive) into a file type.
+    static func parse(_ raw: String) throws -> CiArtifact.Attributes.FileType {
+        guard let match = allCases.first(where: { $0.rawValue.caseInsensitiveCompare(raw) == .orderedSame }) else {
+            let available = allCases.map(\.rawValue).joined(separator: ", ")
+            throw ValidationError("Unknown artifact type '\(raw)'. Available types: \(available)")
+        }
+        return match
+    }
+}

--- a/Tests/ASCTests/Fixtures/RunsFixtures.swift
+++ b/Tests/ASCTests/Fixtures/RunsFixtures.swift
@@ -1,0 +1,161 @@
+/// JSON fixtures matching real App Store Connect CI responses for build runs,
+/// actions, issues and artifacts.
+enum RunsFixtures {
+
+    /// Build runs for a product, including branch (scmGitReferences) and
+    /// workflow (ciWorkflows) names in the `included` payload.
+    static let productBuildRunsResponse = """
+    {
+        "data": [
+            {
+                "type": "ciBuildRuns",
+                "id": "run-128",
+                "attributes": {
+                    "number": 128,
+                    "executionProgress": "COMPLETE",
+                    "completionStatus": "SUCCEEDED",
+                    "createdDate": "2026-07-21T08:00:00+00:00",
+                    "startReason": "MANUAL",
+                    "sourceCommit": { "commitSha": "a1b2c3d4e5f6a7b8" }
+                },
+                "relationships": {
+                    "sourceBranchOrTag": { "data": { "type": "scmGitReferences", "id": "ref-main" } },
+                    "workflow": { "data": { "type": "ciWorkflows", "id": "wf-release" } }
+                }
+            },
+            {
+                "type": "ciBuildRuns",
+                "id": "run-127",
+                "attributes": {
+                    "number": 127,
+                    "executionProgress": "COMPLETE",
+                    "completionStatus": "FAILED",
+                    "createdDate": "2026-07-21T03:00:00+00:00",
+                    "startReason": "GIT_REF_CHANGE",
+                    "sourceCommit": { "commitSha": "9f8e7d6c5b4a3210" }
+                },
+                "relationships": {
+                    "sourceBranchOrTag": { "data": { "type": "scmGitReferences", "id": "ref-main" } },
+                    "workflow": { "data": { "type": "ciWorkflows", "id": "wf-release" } }
+                }
+            }
+        ],
+        "included": [
+            { "type": "scmGitReferences", "id": "ref-main", "attributes": { "name": "main", "kind": "BRANCH" } },
+            { "type": "ciWorkflows", "id": "wf-release", "attributes": { "name": "Release Build" } }
+        ],
+        "links": { "self": "https://api.appstoreconnect.apple.com/v1/ciProducts/ci-product-1/buildRuns" },
+        "meta": { "paging": { "total": 2, "limit": 100 } }
+    }
+    """
+
+    /// Actions of a build run: a succeeded Build and a failed Test.
+    static let actionsResponse = """
+    {
+        "data": [
+            {
+                "type": "ciBuildActions",
+                "id": "action-build",
+                "attributes": {
+                    "name": "Build",
+                    "actionType": "BUILD",
+                    "executionProgress": "COMPLETE",
+                    "completionStatus": "SUCCEEDED",
+                    "issueCounts": { "errors": 0, "warnings": 0, "analyzerWarnings": 0, "testFailures": 0 }
+                }
+            },
+            {
+                "type": "ciBuildActions",
+                "id": "action-test",
+                "attributes": {
+                    "name": "Test",
+                    "actionType": "TEST",
+                    "executionProgress": "COMPLETE",
+                    "completionStatus": "FAILED",
+                    "issueCounts": { "errors": 2, "warnings": 1, "analyzerWarnings": 0, "testFailures": 2 }
+                }
+            }
+        ],
+        "links": { "self": "https://api.appstoreconnect.apple.com/v1/ciBuildRuns/run-127/actions" },
+        "meta": { "paging": { "total": 2, "limit": 50 } }
+    }
+    """
+
+    /// Issues of the failing Test action.
+    static let issuesResponse = """
+    {
+        "data": [
+            {
+                "type": "ciIssues",
+                "id": "issue-1",
+                "attributes": {
+                    "issueType": "ERROR",
+                    "message": "XCTAssertEqual failed",
+                    "category": "Test",
+                    "fileSource": { "path": "MyTests.swift", "lineNumber": 42 }
+                }
+            },
+            {
+                "type": "ciIssues",
+                "id": "issue-2",
+                "attributes": {
+                    "issueType": "ERROR",
+                    "message": "unexpectedly found nil",
+                    "category": "Test",
+                    "fileSource": { "path": "MyTests.swift", "lineNumber": 88 }
+                }
+            }
+        ],
+        "links": { "self": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-test/issues" },
+        "meta": { "paging": { "total": 2, "limit": 200 } }
+    }
+    """
+
+    /// Empty issues (for the succeeded Build action).
+    static let emptyIssuesResponse = """
+    {
+        "data": [],
+        "links": { "self": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-build/issues" },
+        "meta": { "paging": { "total": 0, "limit": 200 } }
+    }
+    """
+
+    /// Artifacts of an action: a log bundle and a result bundle.
+    static let artifactsResponse = """
+    {
+        "data": [
+            {
+                "type": "ciArtifacts",
+                "id": "artifact-log",
+                "attributes": {
+                    "fileType": "LOG_BUNDLE",
+                    "fileName": "Test.xcresult.log.zip",
+                    "fileSize": 4404019,
+                    "downloadUrl": "https://ci-artifacts.example.com/log.zip?X-Amz-Expires=900"
+                }
+            },
+            {
+                "type": "ciArtifacts",
+                "id": "artifact-result",
+                "attributes": {
+                    "fileType": "RESULT_BUNDLE",
+                    "fileName": "Test.xcresult.zip",
+                    "fileSize": 18874368,
+                    "downloadUrl": "https://ci-artifacts.example.com/result.zip?X-Amz-Expires=900"
+                }
+            }
+        ],
+        "links": { "self": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-test/artifacts" },
+        "meta": { "paging": { "total": 2, "limit": 200 } }
+    }
+    """
+
+    /// Empty artifacts (for the succeeded Build action).
+    static let emptyArtifactsResponse = """
+    {
+        "data": [],
+        "links": { "self": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-build/artifacts" },
+        "meta": { "paging": { "total": 0, "limit": 200 } }
+    }
+    """
+}

--- a/Tests/ASCTests/RunsCommandTests.swift
+++ b/Tests/ASCTests/RunsCommandTests.swift
@@ -1,0 +1,159 @@
+import Testing
+import AppStoreConnect_Swift_SDK
+import Foundation
+
+@testable import ASC
+
+// MARK: - Tags
+
+extension Tag {
+    @Tag static var runs: Self
+}
+
+// MARK: - RunsLogic: listing & resolving runs
+
+struct RunsListLogicTests {
+
+    @Test("listRuns parses build runs with branch and workflow names", .tags(.runs))
+    func listRunsParsesResponse() async throws {
+        let (provider, executor) = try TestAPIProvider.make()
+        executor.register(path: "/buildRuns", method: "GET", json: RunsFixtures.productBuildRunsResponse)
+
+        let runs = try await RunsLogic.listRuns(
+            provider: provider,
+            productID: "ci-product-1",
+            workflowID: nil,
+            limit: 100
+        )
+
+        #expect(runs.count == 2)
+        #expect(runs[0].number == 128)
+        #expect(runs[0].workflowName == "Release Build")
+        #expect(runs[0].branch == "main")
+        #expect(runs[0].commitSha == "a1b2c3d")
+        #expect(runs[0].completionStatus == "SUCCEEDED")
+        #expect(runs[1].number == 127)
+        #expect(runs[1].completionStatus == "FAILED")
+    }
+
+    @Test("resolveRun finds a run by its build number", .tags(.runs))
+    func resolveRunByNumber() async throws {
+        let (provider, executor) = try TestAPIProvider.make()
+        executor.register(path: "/buildRuns", method: "GET", json: RunsFixtures.productBuildRunsResponse)
+
+        let run = try await RunsLogic.resolveRun(
+            provider: provider,
+            productID: "ci-product-1",
+            workflowID: nil,
+            number: 127
+        )
+        #expect(run.id == "run-127")
+        #expect(run.completionStatus == "FAILED")
+    }
+
+    @Test("resolveRun throws when the build number is unknown", .tags(.runs))
+    func resolveRunThrowsOnUnknownNumber() async throws {
+        let (provider, executor) = try TestAPIProvider.make()
+        executor.register(path: "/buildRuns", method: "GET", json: RunsFixtures.productBuildRunsResponse)
+
+        await #expect(throws: (any Error).self) {
+            try await RunsLogic.resolveRun(
+                provider: provider,
+                productID: "ci-product-1",
+                workflowID: nil,
+                number: 999
+            )
+        }
+    }
+}
+
+// MARK: - RunsLogic: actions, issues, artifacts
+
+struct RunsActionsLogicTests {
+
+    /// Registers the actions endpoint plus per-action issues and artifacts.
+    private func registerActionRoutes(_ executor: MockRequestExecutor) {
+        executor.register(path: "/actions", method: "GET", json: RunsFixtures.actionsResponse)
+        executor.register(path: "action-test/issues", method: "GET", json: RunsFixtures.issuesResponse)
+        executor.register(path: "action-build/issues", method: "GET", json: RunsFixtures.emptyIssuesResponse)
+        executor.register(path: "action-test/artifacts", method: "GET", json: RunsFixtures.artifactsResponse)
+        executor.register(path: "action-build/artifacts", method: "GET", json: RunsFixtures.emptyArtifactsResponse)
+    }
+
+    @Test("fetchActions parses actions with their issues and artifacts", .tags(.runs))
+    func fetchActionsParsesEverything() async throws {
+        let (provider, executor) = try TestAPIProvider.make()
+        registerActionRoutes(executor)
+
+        let actions = try await RunsLogic.fetchActions(
+            provider: provider,
+            runID: "run-127",
+            query: .init(includeIssues: true, includeArtifacts: true)
+        )
+
+        #expect(actions.count == 2)
+
+        let build = try #require(actions.first { $0.name == "Build" })
+        #expect(build.completionStatus == "SUCCEEDED")
+        #expect(build.issues.isEmpty)
+        #expect(build.artifacts.isEmpty)
+
+        let test = try #require(actions.first { $0.name == "Test" })
+        #expect(test.completionStatus == "FAILED")
+        #expect(test.issueCounts?.errors == 2)
+        #expect(test.issues.count == 2)
+        #expect(test.issues[0].file == "MyTests.swift")
+        #expect(test.issues[0].line == 42)
+        #expect(test.artifacts.count == 2)
+        #expect(test.artifacts.contains { $0.fileType == "LOG_BUNDLE" })
+        #expect(test.artifacts.contains { $0.fileType == "RESULT_BUNDLE" })
+    }
+
+    @Test("fetchActions with onlyFailed keeps just the failed action", .tags(.runs))
+    func fetchActionsOnlyFailed() async throws {
+        let (provider, executor) = try TestAPIProvider.make()
+        registerActionRoutes(executor)
+
+        let actions = try await RunsLogic.fetchActions(
+            provider: provider,
+            runID: "run-127",
+            query: .init(onlyFailed: true, includeIssues: true, includeArtifacts: true)
+        )
+
+        #expect(actions.count == 1)
+        #expect(actions[0].name == "Test")
+    }
+
+    @Test("fetchActions honours the case-insensitive action filter", .tags(.runs))
+    func fetchActionsActionFilter() async throws {
+        let (provider, executor) = try TestAPIProvider.make()
+        registerActionRoutes(executor)
+
+        let actions = try await RunsLogic.fetchActions(
+            provider: provider,
+            runID: "run-127",
+            query: .init(actionFilter: "build")
+        )
+
+        #expect(actions.count == 1)
+        #expect(actions[0].name == "Build")
+    }
+}
+
+// MARK: - Artifact file-type parsing
+
+struct ArtifactFileTypeTests {
+
+    @Test("FileType.parse is case-insensitive", .tags(.runs))
+    func parseCaseInsensitive() throws {
+        #expect(try CiArtifact.Attributes.FileType.parse("log_bundle") == .logBundle)
+        #expect(try CiArtifact.Attributes.FileType.parse("RESULT_BUNDLE") == .resultBundle)
+    }
+
+    @Test("FileType.parse throws on an unknown type", .tags(.runs))
+    func parseThrowsOnUnknown() throws {
+        #expect(throws: (any Error).self) {
+            try CiArtifact.Attributes.FileType.parse("NONSENSE")
+        }
+    }
+}


### PR DESCRIPTION
## Was

Neue `asc runs` Command-Gruppe für Xcode-Cloud-Build-Runs und deren Artefakte, plus ein globales `--json`-Flag.

Die CLI-Struktur folgt dem `gh`-Vorbild: `workflows` verwaltet die Workflow-**Definitionen** (wie `gh workflow`), `runs` arbeitet mit deren **Ausführungen** und Artefakten (wie `gh run`). Resources bleiben flache Top-Level-Nomen (konsistent mit `apps`/`versions`/`workflows`); Zugehörigkeit läuft über das `<app>`-Argument und Filter, nicht über Verschachtelung.

## Commands

```
asc runs list <app> [--workflow N] [--limit K] [--json]       # gh run list
asc runs view <app> <number> [--failed] [--json]              # gh run view
asc runs download <app> <number> [--type T] [--action A]
                                 [--output DIR] [--json]       # gh run download
```

- **list** – letzte Build-Runs (`ciProducts/{id}/buildRuns`, bzw. `ciWorkflows/{id}/buildRuns` mit `--workflow`); Branch- und Workflow-Namen werden aus dem `included`-Payload aufgelöst.
- **view** – löst eine Build-**Nummer** zum Run auf, zeigt Actions mit Issue-Counts; fehlgeschlagene Actions zeigen ihre Issues (Datei/Zeile/Message) inline, Artefakte werden aufgelistet. `--failed` beschränkt auf fehlgeschlagene Actions.
- **download** – holt **frische** vorsignierte Artefakt-URLs und lädt passende Dateien nach `--output` (Default: cwd), damit andere Clients den Build debuggen können. `--type` filtert nach Dateityp (LOG_BUNDLE, RESULT_BUNDLE, ARCHIVE, …), `--action` nach Action-Name.

## Artefakt-Zugriff

Folgt der API-Hierarchie `CiProduct → CiWorkflow → CiBuildRun → CiBuildAction → { CiArtifact, CiIssue }`. Wichtig: **Artefakte hängen an den `CiBuildActions`, nicht am `CiBuildRun`** — es gibt kein `/ciBuildRuns/{id}/artifacts`. `runs download` iteriert daher die Actions und sammelt deren Artefakte.

`CiArtifact.downloadUrl` ist eine **kurzlebige, vorsignierte URL** (kein ASC-Credential nötig, läuft aber nach Minuten ab). `runs download` holt sie unmittelbar vor dem Download frisch und lädt per `URLSession` — die URL wird nie als dauerhafter Link behandelt.

## Globales `--json`

Neues `JSONOutput`-Helper + `--json`-Flag. Jedes datenliefernde Command gibt bei `--json` genau **ein** JSON-Dokument aus und unterdrückt die menschenlesbare Ausgabe, damit andere Clients es parsen können. Aktuell verdrahtet in: `apps list`, `versions show`, `workflows list`, `workflows status` und allen `runs`-Commands.

## Tests

`RunsLogic` (Parsing der Runs inkl. Branch/Workflow-Namen, Auflösung per Build-Nummer, Actions mit Issues+Artefakten, `onlyFailed`/`actionFilter`) und Artefakt-Typ-Parsing — gegen Mock-API-Responses im vorhandenen `MockRequestExecutor`-Muster. **39 Tests grün.**

## CLAUDE.md

Auf aktuellen Stand gebracht: `runs`-Commands, `--json`, die `ASCMain`-Library-/`ASCExecutable`-Wrapper-Aufteilung, `VersionLogic`/`RunsLogic`/`JSONOutput`, und die Runs/Artefakt-API-Details.

## Hinweise

- Basis-Branch ist `feature/issue-10-workflows-and-cli-restructuring` (baut auf dessen Workflow-/CLI-Arbeit auf), damit der Diff nur die neue Arbeit zeigt.
- `--json` ist zunächst auf die datenliefernden Commands beschränkt; für die mutierenden Commands (`create`/`submit`/`trigger`/`select-build`) kann es als Follow-up ergänzt werden.
